### PR TITLE
test: add form submission unit test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "cichociemny",
+  "version": "1.0.0",
+  "description": "Nejlepší přítel Milionka",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.6.0",
+    "jsdom": "^22.0.0"
+  }
+}

--- a/tests/form.test.js
+++ b/tests/form.test.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('form submission', () => {
+  test('calls fetch with expected payload and updates DOM', async () => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+    const dom = new JSDOM(html, {
+      runScripts: 'dangerously',
+      resources: 'usable',
+      url: 'http://localhost/?name=Alice&relationship=friend'
+    });
+
+    const { window } = dom;
+
+    window.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({ answer: 'Hello' })
+      })
+    );
+
+    await new Promise(resolve => {
+      if (window.document.readyState === 'complete') {
+        resolve();
+      } else {
+        window.addEventListener('load', resolve);
+      }
+    });
+
+    window.document.getElementById('question').value = 'How are you?';
+
+    window.document
+      .getElementById('questionForm')
+      .dispatchEvent(new window.Event('submit', { bubbles: true, cancelable: true }));
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(window.fetch).toHaveBeenCalledWith('https://tvujbackend.glitch.me/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Alice', relationship: 'friend', question: 'How are you?' })
+    });
+
+    expect(window.document.getElementById('answer').textContent).toBe('Hello');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest-based test for form submission
- define test script and dev dependencies in `package.json`

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a1f095630832b9e66a092dcb288e3